### PR TITLE
fix: adds exponential backoff retries to failure responses in price feed stream

### DIFF
--- a/src/price-stream/polling-price-stream/polling-price-stream.test.ts
+++ b/src/price-stream/polling-price-stream/polling-price-stream.test.ts
@@ -82,7 +82,7 @@ describe("pollPriceStream", () => {
       .mockResolvedValueOnce(mockFetchResponse(data, 500))
       .mockResolvedValueOnce(mockFetchResponse(data));
 
-    const options = createOptions({ fetch: fetchMock, logger });
+    const options = createOptions({ fetch: fetchMock, logger, delay: mockDelay() });
     const gen = pollPriceStream(options);
     const result = await gen.next();
 
@@ -105,7 +105,7 @@ describe("pollPriceStream", () => {
       .mockResolvedValueOnce(mockFetchResponse(createHermesResponse({ parsed: [] })))
       .mockResolvedValueOnce(mockFetchResponse(goodData));
 
-    const options = createOptions({ fetch: fetchMock, logger });
+    const options = createOptions({ fetch: fetchMock, logger, delay: mockDelay() });
     const gen = pollPriceStream(options);
     const result = await gen.next();
 
@@ -120,12 +120,110 @@ describe("pollPriceStream", () => {
       .mockResolvedValueOnce(mockFetchResponse(createHermesResponse({ binary: { data: [] } })))
       .mockResolvedValueOnce(mockFetchResponse(goodData));
 
-    const options = createOptions({ fetch: fetchMock, logger });
+    const options = createOptions({ fetch: fetchMock, logger, delay: mockDelay() });
     const gen = pollPriceStream(options);
     const result = await gen.next();
 
     expect(logger.error).toHaveBeenCalledWith("No VAA binary data returned from Hermes");
     expect(result.value).toEqual({ priceData: goodData.parsed[0], vaa: goodData.binary.data[0] });
+  });
+
+  it("backs off exponentially across consecutive failures", async () => {
+    const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const data = createHermesResponse();
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(mockFetchResponse(data, 500))
+      .mockResolvedValueOnce(mockFetchResponse(data, 503))
+      .mockResolvedValueOnce(mockFetchResponse(data));
+    const delayMock = mockDelay();
+
+    const options = createOptions({ fetch: fetchMock, logger, delay: delayMock });
+    const gen = pollPriceStream(options);
+    const result = await gen.next();
+
+    expect(result.value).toEqual({ priceData: data.parsed[0], vaa: data.binary.data[0] });
+    expect(delayDurations(delayMock)).toEqual([500, 1000, 2000]);
+    expect(logger.warn).toHaveBeenCalledWith("Retrying fetch from Hermes in 500 ms (attempt 1)");
+    expect(logger.warn).toHaveBeenCalledWith("Retrying fetch from Hermes in 2000 ms (attempt 3)");
+  });
+
+  it("uses the configured base delay for the first retry", async () => {
+    const data = createHermesResponse();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse(data, 500))
+      .mockResolvedValueOnce(mockFetchResponse(data));
+    const delayMock = mockDelay();
+
+    const options = createOptions({ fetch: fetchMock, delay: delayMock, retryBaseDelayMs: 25 });
+    const gen = pollPriceStream(options);
+    await gen.next();
+
+    expect(delayDurations(delayMock)).toEqual([25]);
+  });
+
+  it("caps the backoff at the configured maximum delay", async () => {
+    const controller = new AbortController();
+    const data = createHermesResponse();
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse(data, 500));
+    // The generator retries forever while fetches fail, so stop it after five backoffs
+    const durations: number[] = [];
+    const delayMock = mockDelay().mockImplementation(async (ms) => {
+      durations.push(ms as number);
+      if (durations.length >= 5) controller.abort();
+    });
+
+    const options = createOptions({
+      fetch: fetchMock,
+      delay: delayMock,
+      signal: controller.signal,
+      retryBaseDelayMs: 100,
+      retryMaxDelayMs: 400,
+    });
+    const result = await pollPriceStream(options).next();
+
+    expect(result.done).toBe(true);
+    expect(durations).toEqual([100, 200, 400, 400, 400]);
+  });
+
+  it("resets the backoff after a successful poll", async () => {
+    const data = createHermesResponse();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse(data, 500))
+      .mockResolvedValueOnce(mockFetchResponse(data, 500))
+      .mockResolvedValueOnce(mockFetchResponse(data))
+      .mockResolvedValueOnce(mockFetchResponse(data, 500))
+      .mockResolvedValueOnce(mockFetchResponse(data));
+    const delayMock = mockDelay();
+
+    const options = createOptions({ fetch: fetchMock, delay: delayMock, pollingIntervalMs: 0 });
+    const gen = pollPriceStream(options);
+    await gen.next();
+    await gen.next();
+
+    // 500, 1000 before the first success; back to 500 after it
+    expect(delayDurations(delayMock)).toEqual([500, 1000, 500]);
+  });
+
+  it("stops when signal is aborted during the retry backoff", async () => {
+    const controller = new AbortController();
+    const data = createHermesResponse();
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse(data, 500));
+    const options = createOptions({
+      fetch: fetchMock,
+      retryBaseDelayMs: 60_000,
+      signal: controller.signal,
+    });
+
+    const gen = pollPriceStream(options);
+    const resultPromise = gen.next();
+    await vi.waitUntil(() => fetchMock.mock.calls.length === 1);
+    controller.abort();
+
+    const result = await resultPromise;
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("polls repeatedly yielding updates", async () => {
@@ -215,6 +313,14 @@ function createOptions(overrides?: Partial<PollPriceStreamOptions>): PollPriceSt
     fetch: vi.fn(),
     ...overrides,
   };
+}
+
+function mockDelay() {
+  return vi.fn<NonNullable<PollPriceStreamOptions["delay"]>>().mockResolvedValue(undefined);
+}
+
+function delayDurations(delayMock: ReturnType<typeof mockDelay>): number[] {
+  return delayMock.mock.calls.map(([ms]) => ms as number);
 }
 
 function mockFetchResponse(data: HermesResponse, status = 200): Response {

--- a/src/price-stream/polling-price-stream/polling-price-stream.test.ts
+++ b/src/price-stream/polling-price-stream/polling-price-stream.test.ts
@@ -226,6 +226,41 @@ describe("pollPriceStream", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retries when the per-request timeout aborts the fetch", async () => {
+    const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const data = createHermesResponse();
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(createAbortError())
+      .mockRejectedValueOnce(new DOMException("The operation timed out.", "TimeoutError"))
+      .mockResolvedValueOnce(mockFetchResponse(data));
+    const delayMock = mockDelay();
+
+    const options = createOptions({ fetch: fetchMock, logger, delay: delayMock });
+    const result = await pollPriceStream(options).next();
+
+    expect(result.done).toBe(false);
+    expect(result.value).toEqual({ priceData: data.parsed[0], vaa: data.binary.data[0] });
+    expect(logger.error).toHaveBeenCalledWith("Timed out fetching from Hermes after 10000 ms");
+    expect(delayDurations(delayMock)).toEqual([500, 1000]);
+  });
+
+  it("stops when the caller signal aborts the fetch", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(createAbortError());
+    });
+    const delayMock = mockDelay();
+
+    const options = createOptions({ fetch: fetchMock, delay: delayMock, signal: controller.signal });
+    const result = await pollPriceStream(options).next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(delayMock).not.toHaveBeenCalled();
+  });
+
   it("polls repeatedly yielding updates", async () => {
     const data1 = createHermesResponse();
     const data2 = createHermesResponse({
@@ -321,6 +356,14 @@ function mockDelay() {
 
 function delayDurations(delayMock: ReturnType<typeof mockDelay>): number[] {
   return delayMock.mock.calls.map(([ms]) => ms as number);
+}
+
+// Mirrors the AbortError the built-in fetch implementation rejects with, which is
+// indistinguishable between a caller abort and the per-request timeout.
+function createAbortError(): Error {
+  const error = new Error("AbortError");
+  error.name = "AbortError";
+  return error;
 }
 
 function mockFetchResponse(data: HermesResponse, status = 200): Response {

--- a/src/price-stream/polling-price-stream/polling-price-stream.ts
+++ b/src/price-stream/polling-price-stream/polling-price-stream.ts
@@ -21,71 +21,109 @@ export async function *pollPriceStream(options: PollPriceStreamOptions): AsyncGe
     encoding: "base64",
   });
   const fetch = options.fetch ?? createFetch();
+  const sleep = options.delay ?? delay;
+  const retryBaseDelayMs = options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const retryMaxDelayMs = options.retryMaxDelayMs ?? DEFAULT_RETRY_MAX_DELAY_MS;
   const headers: Record<string, string> = {};
+
   if (options.authenticationToken) {
     headers["Authorization"] = `Bearer ${options.authenticationToken}`;
   }
 
-  let response: Response | undefined;
-  let status = 0;
-  while (!options.signal?.aborted) {
+  const url = `${options.baseUrl}/v2/updates/price/latest?${params.toString()}`;
+
+  // Fetches a single price update, mapping every failure mode onto a result so the
+  // polling loop below can decide between backing off and stopping.
+  const fetchPriceUpdate = async (): Promise<FetchAttempt> => {
     const fetchStart = performance.now();
-    response = undefined;
-    status = 0;
+    let response: Response;
+    let status = 0;
     try {
       const timeoutSignal = AbortSignal.timeout(10_000);
-      response = await fetch(`${options.baseUrl}/v2/updates/price/latest?${params.toString()}`, {
+      response = await fetch(url, {
         signal: options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal,
         headers,
       });
       status = response.status;
     } catch (error) {
       if (error instanceof Error && (error.name === "AbortError" || error.message === "AbortError")) {
-        break;
+        return { status: "aborted" };
       }
-      options.logger?.error(`Error fetching from Hermes: ${(error as Error).message}`);
-      continue;
+      return { status: "failed", message: `Error fetching from Hermes: ${(error as Error).message}` };
     } finally {
       hermesFetchDuration.record(performance.now() - fetchStart, { status });
     }
 
     if (!response.ok) {
       const statusText = response.status ? ` (HTTP ${response.status})` : "";
-      options.logger?.error(
-        `Failed to fetch from Hermes${statusText}: price data unavailable`,
-      );
-      continue;
+      return {
+        status: "failed",
+        message: `Failed to fetch from Hermes${statusText}: price data unavailable`,
+      };
     }
 
     let parsedData: HermesResponse;
     try {
       parsedData = await response.json() as HermesResponse;
     } catch (error) {
-      options.logger?.error(`Error parsing JSON from Hermes: ${(error as Error).message}`);
-      continue;
+      return { status: "failed", message: `Error parsing JSON from Hermes: ${(error as Error).message}` };
     }
 
     const priceUpdateResult = parsePriceUpdate(parsedData);
 
     if (!priceUpdateResult.ok) {
-      options.logger?.error(priceUpdateResult.message);
+      return { status: "failed", message: priceUpdateResult.message };
+    }
+
+    return { status: "ok", value: priceUpdateResult.value };
+  };
+
+  let consecutiveFailures = 0;
+  while (!options.signal?.aborted) {
+    const attempt = await fetchPriceUpdate();
+
+    if (attempt.status === "aborted") {
+      break;
+    }
+
+    if (attempt.status === "failed") {
+      options.logger?.error(attempt.message);
+      const backoffMs = Math.min(retryBaseDelayMs * 2 ** consecutiveFailures, retryMaxDelayMs);
+      consecutiveFailures++;
+      options.logger?.warn(`Retrying fetch from Hermes in ${backoffMs} ms (attempt ${consecutiveFailures})`);
+      await sleep(backoffMs, undefined, { signal: options.signal })
+        .catch((error) => options.logger?.warn(`Retry delay interrupted: ${(error as Error).message}`));
       continue;
     }
 
-    yield priceUpdateResult.value;
+    consecutiveFailures = 0;
+    yield attempt.value;
     if (options.pollingIntervalMs > 0) {
-      await delay(options.pollingIntervalMs, undefined, { signal: options.signal })
+      await sleep(options.pollingIntervalMs, undefined, { signal: options.signal })
         .catch((error) => options.logger?.warn(`Polling delay interrupted: ${(error as Error).message}`));
     }
   }
 }
 
+const DEFAULT_RETRY_BASE_DELAY_MS = 500;
+const DEFAULT_RETRY_MAX_DELAY_MS = 5_000;
+
+type FetchAttempt =
+  | { status: "ok"; value: PriceUpdate }
+  | { status: "aborted" }
+  | { status: "failed"; message: string };
+
 export interface PollPriceStreamOptions extends PriceProducerFactoryOptions {
   baseUrl: string;
   authenticationToken?: string;
   pollingIntervalMs: number;
+  /** First retry delay after a failed poll; doubles on each consecutive failure. Defaults to 500 ms. */
+  retryBaseDelayMs?: number;
+  /** Upper bound for the exponential retry delay. Defaults to 5000 ms. */
+  retryMaxDelayMs?: number;
   unsafeAllowInsecureEndpoints?: boolean;
   fetch?: typeof globalThis.fetch;
+  delay?: typeof delay;
 }
 
 function createFetch() {

--- a/src/price-stream/polling-price-stream/polling-price-stream.ts
+++ b/src/price-stream/polling-price-stream/polling-price-stream.ts
@@ -39,17 +39,24 @@ export async function *pollPriceStream(options: PollPriceStreamOptions): AsyncGe
     let response: Response;
     let status = 0;
     try {
-      const timeoutSignal = AbortSignal.timeout(10_000);
+      const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
       response = await fetch(url, {
         signal: options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal,
         headers,
       });
       status = response.status;
     } catch (error) {
-      if (error instanceof Error && (error.name === "AbortError" || error.message === "AbortError")) {
+      if (!isAbortError(error)) {
+        return { status: "failed", message: `Error fetching from Hermes: ${(error as Error).message}` };
+      }
+
+      if (options.signal?.aborted) {
         return { status: "aborted" };
       }
-      return { status: "failed", message: `Error fetching from Hermes: ${(error as Error).message}` };
+      return {
+        status: "failed",
+        message: `Timed out fetching from Hermes after ${REQUEST_TIMEOUT_MS} ms`,
+      };
     } finally {
       hermesFetchDuration.record(performance.now() - fetchStart, { status });
     }
@@ -105,8 +112,14 @@ export async function *pollPriceStream(options: PollPriceStreamOptions): AsyncGe
   }
 }
 
+const REQUEST_TIMEOUT_MS = 10_000;
 const DEFAULT_RETRY_BASE_DELAY_MS = 500;
 const DEFAULT_RETRY_MAX_DELAY_MS = 5_000;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error
+    && (error.name === "AbortError" || error.name === "TimeoutError" || error.message === "AbortError");
+}
 
 type FetchAttempt =
   | { status: "ok"; value: PriceUpdate }


### PR DESCRIPTION
## Why

in case of price fetch failure, hermes client retries to fetch too quickly